### PR TITLE
Max Scale Factor for FP4

### DIFF
--- a/src/models/layers/linear.rs
+++ b/src/models/layers/linear.rs
@@ -1198,7 +1198,7 @@ impl LnNvfp4 {
                     vb.get_with_hints_dtype((), "weight_global_scale", no_shard, DType::F32)?
                 }
             };
-            let raw = t.flatten_all()?.to_vec1::<f32>()?[0];
+            let raw = t.flatten_all()?.max(0)?.to_scalar::<f32>()?;
             if raw != 0.0 {
                 1.0 / raw
             } else {
@@ -1210,7 +1210,7 @@ impl LnNvfp4 {
                 Ok(t) => t,
                 Err(_) => vb.get_with_hints_dtype((), "weight_scale_2", no_shard, DType::F32)?,
             };
-            t.flatten_all()?.to_vec1::<f32>()?[0]
+            t.flatten_all()?.max(0)?.to_scalar::<f32>()?
         } else {
             1.0f32
         };
@@ -1221,7 +1221,7 @@ impl LnNvfp4 {
                 Ok(t) => t,
                 Err(_) => vb.get_with_hints_dtype((), "input_scale", no_shard, DType::F32)?,
             };
-            t.flatten_all()?.to_vec1::<f32>()?[0]
+            t.flatten_all()?.max(0)?.to_scalar::<f32>()?
         } else if vb.contains_tensor("input_global_scale") {
             // compressed-tensors format: input_global_scale is a divisor, invert it
             let t = match vb.get_with_hints_dtype((1,), "input_global_scale", no_shard, DType::F32)
@@ -1231,7 +1231,7 @@ impl LnNvfp4 {
                     vb.get_with_hints_dtype((), "input_global_scale", no_shard, DType::F32)?
                 }
             };
-            let raw = t.flatten_all()?.to_vec1::<f32>()?[0];
+            let raw = t.flatten_all()?.max(0)?.to_scalar::<f32>()?;
             if raw != 0.0 {
                 1.0 / raw
             } else {

--- a/src/models/layers/moe.rs
+++ b/src/models/layers/moe.rs
@@ -1805,7 +1805,7 @@ impl FusedMoeNvfp4 {
                 .or_else(|_| {
                     vb.get_with_hints_dtype((), "weight_global_scale", no_shard, DType::F32)
                 })
-                .and_then(|t| t.flatten_all()?.to_vec1::<f32>().map(|v| v[0]))
+                .and_then(|t| t.flatten_all()?.max(0)?.to_scalar::<f32>())
                 .unwrap_or(1.0);
             if raw != 0.0 {
                 1.0 / raw
@@ -1816,7 +1816,7 @@ impl FusedMoeNvfp4 {
             // modelopt format: weight_scale_2 is the direct multiplier
             vb.get_with_hints_dtype((1,), "weight_scale_2", no_shard, DType::F32)
                 .or_else(|_| vb.get_with_hints_dtype((), "weight_scale_2", no_shard, DType::F32))
-                .and_then(|t| t.flatten_all()?.to_vec1::<f32>().map(|v| v[0]))
+                .and_then(|t| t.flatten_all()?.max(0)?.to_scalar::<f32>())
                 .unwrap_or(1.0)
         } else {
             1.0
@@ -1828,7 +1828,7 @@ impl FusedMoeNvfp4 {
         if vb.contains_tensor("input_scale") {
             vb.get_with_hints_dtype((1,), "input_scale", no_shard, DType::F32)
                 .or_else(|_| vb.get_with_hints_dtype((), "input_scale", no_shard, DType::F32))
-                .and_then(|t| t.flatten_all()?.to_vec1::<f32>().map(|v| v[0]))
+                .and_then(|t| t.flatten_all()?.max(0)?.to_scalar::<f32>())
                 .unwrap_or(1.0)
         } else if vb.contains_tensor("input_global_scale") {
             let raw = vb
@@ -1836,7 +1836,7 @@ impl FusedMoeNvfp4 {
                 .or_else(|_| {
                     vb.get_with_hints_dtype((), "input_global_scale", no_shard, DType::F32)
                 })
-                .and_then(|t| t.flatten_all()?.to_vec1::<f32>().map(|v| v[0]))
+                .and_then(|t| t.flatten_all()?.max(0)?.to_scalar::<f32>())
                 .unwrap_or(1.0);
             if raw != 0.0 {
                 1.0 / raw
@@ -1984,7 +1984,7 @@ impl FusedMoeNvfp4 {
                                 DType::F32,
                             )
                         })
-                        .and_then(|t| t.flatten_all()?.to_vec1::<f32>().map(|v| v[0]))
+                        .and_then(|t| t.flatten_all()?.max(0)?.to_scalar::<f32>())
                         .unwrap_or(1.0)
                     } else if vb.contains_tensor("gate_up_proj_weight_global_scale") {
                         let raw = vb
@@ -2002,7 +2002,7 @@ impl FusedMoeNvfp4 {
                                     DType::F32,
                                 )
                             })
-                            .and_then(|t| t.flatten_all()?.to_vec1::<f32>().map(|v| v[0]))
+                            .and_then(|t| t.flatten_all()?.max(0)?.to_scalar::<f32>())
                             .unwrap_or(1.0);
                         if raw != 0.0 {
                             1.0 / raw
@@ -2028,7 +2028,7 @@ impl FusedMoeNvfp4 {
                                 DType::F32,
                             )
                         })
-                        .and_then(|t| t.flatten_all()?.to_vec1::<f32>().map(|v| v[0]))
+                        .and_then(|t| t.flatten_all()?.max(0)?.to_scalar::<f32>())
                         .unwrap_or(1.0)
                     } else if vb.contains_tensor("gate_up_proj_input_global_scale") {
                         let raw = vb
@@ -2046,7 +2046,7 @@ impl FusedMoeNvfp4 {
                                     DType::F32,
                                 )
                             })
-                            .and_then(|t| t.flatten_all()?.to_vec1::<f32>().map(|v| v[0]))
+                            .and_then(|t| t.flatten_all()?.max(0)?.to_scalar::<f32>())
                             .unwrap_or(1.0);
                         if raw != 0.0 {
                             1.0 / raw
@@ -2097,7 +2097,7 @@ impl FusedMoeNvfp4 {
                                 DType::F32,
                             )
                         })
-                        .and_then(|t| t.flatten_all()?.to_vec1::<f32>().map(|v| v[0]))
+                        .and_then(|t| t.flatten_all()?.max(0)?.to_scalar::<f32>())
                         .unwrap_or(1.0)
                     } else if vb.contains_tensor("down_proj_weight_global_scale") {
                         let raw = vb
@@ -2115,7 +2115,7 @@ impl FusedMoeNvfp4 {
                                     DType::F32,
                                 )
                             })
-                            .and_then(|t| t.flatten_all()?.to_vec1::<f32>().map(|v| v[0]))
+                            .and_then(|t| t.flatten_all()?.max(0)?.to_scalar::<f32>())
                             .unwrap_or(1.0);
                         if raw != 0.0 {
                             1.0 / raw
@@ -2136,7 +2136,7 @@ impl FusedMoeNvfp4 {
                                     DType::F32,
                                 )
                             })
-                            .and_then(|t| t.flatten_all()?.to_vec1::<f32>().map(|v| v[0]))
+                            .and_then(|t| t.flatten_all()?.max(0)?.to_scalar::<f32>())
                             .unwrap_or(1.0)
                     } else if vb.contains_tensor("down_proj_input_global_scale") {
                         let raw = vb
@@ -2154,7 +2154,7 @@ impl FusedMoeNvfp4 {
                                     DType::F32,
                                 )
                             })
-                            .and_then(|t| t.flatten_all()?.to_vec1::<f32>().map(|v| v[0]))
+                            .and_then(|t| t.flatten_all()?.max(0)?.to_scalar::<f32>())
                             .unwrap_or(1.0);
                         if raw != 0.0 {
                             1.0 / raw


### PR DESCRIPTION
Alter scale factor computation in to use `max(0)?.to_scalar::<f32>()?` vs `.to_vec1::<f32>()?[0]` in order to get the maximum scale instead of the first one.